### PR TITLE
Enable caching for Salesforce Forms

### DIFF
--- a/djangocms_salesforce_forms/cms_plugins.py
+++ b/djangocms_salesforce_forms/cms_plugins.py
@@ -15,6 +15,7 @@ from .views import djangocms_salesforce_form_submit
 
 
 class SalesforceForm(FormPlugin):
+    cache = True
     name = _('Salesforce Form')
     form = SalesforcePluginForm
     model = SalesforceFormPlugin


### PR DESCRIPTION
Unlike aldryn_forms.FormPlugin, SalesforceForms plugin is just static, sending data. Therefore  we could set cache = True for it.